### PR TITLE
Also allow use of M-w to copy the region

### DIFF
--- a/zop-to-char.el
+++ b/zop-to-char.el
@@ -83,7 +83,7 @@
                      (kill-region
                       beg (if zop-to-char--delete-up-to-char
                               (1- end) end)) nil)
-                    (?\C-c         ; Copy region.
+                    ((?\C-c ?\M-w) ; Copy region.
                      (copy-region-as-kill
                       beg (if zop-to-char--delete-up-to-char
                               (1- end) end))


### PR DESCRIPTION
Most Emacs users will be more accustomed to M-w for copying than C-c.