### PR TITLE
Don't select empty region in backward direction

### DIFF
--- a/zop-to-char.el
+++ b/zop-to-char.el
@@ -208,8 +208,10 @@ of given character.  If ARG is negative, jump in backward direction."
            (condition-case _err
                (let ((case-fold-search (zop-to-char--set-case-fold-search char)))
                  (if (< arg 0)
-                     (search-backward
-                      char (and mini-p (field-beginning)) t (- arg))
+                     (progn
+                       (forward-char -1)
+                       (search-backward
+                        char (and mini-p (field-beginning)) t (- arg)))
                      (forward-char 1)
                      (search-forward char nil t arg)
                      (forward-char -1))


### PR DESCRIPTION
The call `(forward-char -1)` makes sure that when target char is found immediately before point we don't select empty region, but skip the char and search further. Empty region to operate on is rarely what user wants.

Note that this trick is already used in existing code, but only when searching in forward direction. This commit adds the same behavior for searching in backward direction too.

I've noticed that you prefer another indentation scheme, so I disabled `aggressive-indent-mode` to avoid re-indenting this time.
